### PR TITLE
Multi theme options

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -65,7 +65,7 @@ function composer_autoload() {
 get_template_part( 'lib/custom-gallery' );
 get_template_part( 'lib/post-types' );
 get_template_part( 'lib/meta-boxes' );
-get_template_part( 'lib/theme-options' );
+get_template_part( 'lib/theme-options/theme-options' );
 
 // Add custom functions
 

--- a/lib/theme-options/site-options.php
+++ b/lib/theme-options/site-options.php
@@ -1,0 +1,106 @@
+<?php
+// SITE OPTIONS
+$prefix = '_igv_';
+$suffix = '_options';
+
+$page_key = $prefix . 'site' . $suffix;
+$page_title = 'Site Options';
+$metabox = array(
+  'id'         => $page_key, //id used as tab page slug, must be unique
+  'title'      => $page_title,
+  'show_on'    => array( 'key' => 'options-page', 'value' => array( $page_key ), ), //value must be same as id
+  'show_names' => true,
+  'fields'     => array(
+    array(
+      'name' => __( 'Social Media', 'cmb2' ),
+      'desc' => __( 'urls and accounts for different social media platforms. For use in menus and metadata', 'cmb2' ),
+      'id'   => $prefix . 'socialmedia_title',
+      'type' => 'title',
+    ),
+    array(
+      'name' => __( 'Facebook Page URL', 'IGV' ),
+      'desc' => __( '', 'IGV' ),
+      'id'   => $prefix . 'socialmedia_facebook_url',
+      'type' => 'text',
+    ),
+    array(
+      'name' => __( 'Twitter Account Handle', 'IGV' ),
+      'desc' => __( '', 'IGV' ),
+      'id'   => $prefix . 'socialmedia_twitter',
+      'type' => 'text',
+    ),
+    array(
+      'name' => __( 'Instagram Account Handle', 'IGV' ),
+      'desc' => __( '', 'IGV' ),
+      'id'   => $prefix . 'socialmedia_instagram',
+      'type' => 'text',
+    ),
+
+    // METADATA OPTIONS
+
+    array(
+      'name' => __( 'Metadata options', 'cmb2' ),
+      'desc' => __( 'Settings relating to open graph, facebook and twitter sharing, and other social media metadata', 'cmb2' ),
+      'id'   => $prefix . 'og_title',
+      'type' => 'title',
+    ),
+    array(
+      'name' => __( 'Open Graph default image', 'IGV' ),
+      'desc' => __( 'primarily displayed on Facebook, but other locations as well', 'IGV' ),
+      'id'   => $prefix . 'og_image',
+      'type' => 'file',
+    ),
+    array(
+      'name' => __( 'Logo for SEO results', 'IGV' ),
+      'desc' => __( '(options) ', 'IGV' ),
+      'id'   => $prefix . 'metadata_logo',
+      'type' => 'file',
+    ),
+    array(
+      'name' => __( 'Facebook App ID', 'IGV' ),
+      'desc' => __( '(optional)', 'IGV' ),
+      'id'   => $prefix . 'og_fb_app_id',
+      'type' => 'text',
+    ),
+
+    // BOILER
+
+    array(
+      'name' => __( 'Analytics', 'cmb2' ),
+      'desc' => __( '', 'cmb2' ),
+      'id'   => $prefix . 'analytics_title',
+      'type' => 'title',
+    ),
+    array(
+      'name' => __( 'Google Analytics Tracking ID', 'IGV' ),
+      'desc' => __( '(optional)', 'IGV' ),
+      'id'   => $prefix . 'google_analytics_id',
+      'type' => 'text',
+    ),
+
+    // BOILER
+
+    array(
+      'name' => __( 'Title for options section', 'cmb2' ),
+      'desc' => __( '', 'cmb2' ),
+      'id'   => $prefix . 'general_title',
+      'type' => 'title',
+    ),
+    array(
+      'name' => __( 'Test Text', 'IGV' ),
+      'desc' => __( 'field description (optional)', 'IGV' ),
+      'id'   => $prefix . 'test_text',
+      'type' => 'text',
+      'default' => 'Default Text',
+    ),
+    array(
+      'name'    => __( 'Test Color Picker', 'IGV' ),
+      'desc'    => __( 'field description (optional)', 'IGV' ),
+      'id'      => $prefix . 'test_colorpicker',
+      'type'    => 'colorpicker',
+      'default' => '#bada55',
+    )
+  )
+);
+
+IGV_init_options_page($page_key, $page_key, $page_title, $metabox);

--- a/lib/theme-options/theme-options-class.php
+++ b/lib/theme-options/theme-options-class.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * CMB2 Theme Options
+ * @version 0.1.0
+ */
+class IGV_Admin {
+
+  /**
+    * Option key, and option page slug
+    * @var string
+    */
+  private $key = 'IGV_options';
+
+  /**
+    * Options page metabox id
+    * @var string
+    */
+  private $metabox_id = 'IGV_option_metabox';
+
+  /**
+   * Metabox array
+   * @var array
+   */
+  private $metabox = '';
+
+  /**
+   * Options Page title
+   * @var string
+   */
+  protected $title = 'Site Options';
+
+  /**
+   * Options Page hook
+   * @var string
+   */
+  protected $options_page = '';
+
+  /**
+   * Constructor
+   * @since 0.1.0
+   */
+  public function __construct($key, $metabox_id, $title, $metabox) {
+    // Set our title
+    $this->key = $key;
+    $this->metabox_id = $metabox_id;
+    $this->title = $title;
+    $this->metabox = $metabox;
+  }
+
+  /**
+   * Initiate our hooks
+   * @since 0.1.0
+   */
+  public function hooks() {
+    add_action( 'admin_init', array( $this, 'init' ) );
+    add_action( 'admin_menu', array( $this, 'add_options_page' ) );
+    add_action( 'cmb2_init', array( $this, 'add_options_page_metabox' ) );
+  }
+
+  /**
+   * Register our setting to WP
+   * @since  0.1.0
+   */
+  public function init() {
+    register_setting( $this->key, $this->key );
+  }
+
+  /**
+   * Add menu options page
+   * @since 0.1.0
+   */
+  public function add_options_page() {
+    $this->options_page = add_menu_page( $this->title, $this->title, 'upload_files', $this->key, array( $this, 'admin_page_display' ) );
+  }
+
+  /**
+   * Admin page markup. Mostly handled by CMB2
+   * @since  0.1.0
+   */
+  public function admin_page_display() {
+    ?>
+    <div class="wrap cmb2-options-page <?php echo $this->key; ?>">
+      <h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
+      <?php cmb2_metabox_form( $this->metabox_id, $this->key ); ?>
+    </div>
+    <?php
+  }
+
+  /**
+   * Add the options metabox to the array of metaboxes
+   * @since  0.1.0
+   */
+  function add_options_page_metabox() {
+
+    new_cmb2_box( $this->metabox );
+
+  }
+
+  /**
+   * Public getter method for retrieving protected/private variables
+   * @since  0.1.0
+   * @param  string  $field Field to retrieve
+   * @return mixed          Field value or exception is thrown
+   */
+  public function __get( $field ) {
+    // Allowed fields to retrieve
+    if ( in_array( $field, array( 'key', 'metabox_id', 'title', 'options_page' ), true ) ) {
+      return $this->{$field};
+    }
+
+    throw new Exception( 'Invalid property: ' . $field );
+  }
+
+}
+
+/**
+ * Init options page
+ */
+function IGV_init_options_page($key, $metabox_id, $title, $metabox) {
+  $object = new IGV_Admin($key, $metabox_id, $title, $metabox);
+  $object->hooks();
+}
+
+/**
+ * Wrapper function around cmb2_get_option
+ * @since  0.1.0
+ * @param  string  $key Options array key
+ * @return mixed        Option value
+ */
+function IGV_get_option( $page_key = '', $field_key = '' ) {
+  return cmb2_get_option( $page_key, $field_key );
+}

--- a/lib/theme-options/theme-options.php
+++ b/lib/theme-options/theme-options.php
@@ -1,0 +1,7 @@
+<?php
+
+// Include main Theme Options Class
+get_template_part( 'lib/theme-options/theme-options-class' );
+
+// One file per options page
+get_template_part( 'lib/theme-options/site-options' );

--- a/partials/scripts.php
+++ b/partials/scripts.php
@@ -1,5 +1,23 @@
 <section id="scripts">
   <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="<?php bloginfo('stylesheet_directory'); ?>/js/vendor/jquery-2.1.1.min.js"><\/script>')</script>
+<?php 
+$google_tracking_id = IGV_get_option('_igv_site_options', '_igv_google_analytics_id');
+
+if (!empty($google_tracking_id)) {
+?>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '<?php echo $google_tracking_id; ?>', 'auto');
+    ga('send', 'pageview');
+
+  </script>
+<?php 
+}
+?>
   <?php wp_footer(); ?>
 </section>


### PR DESCRIPTION
add functionality for multiple theme options pages. add google analytics tracking ID field to site options. add google analytics script in footer. set theme options capability to `upload-files` for Editors to access. close #71 close #72 